### PR TITLE
Extend FailureHandler interface with the ability to register metrics

### DIFF
--- a/src/main/java/org/sourcelab/storm/spout/redis/FailureHandler.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/FailureHandler.java
@@ -1,5 +1,7 @@
 package org.sourcelab.storm.spout.redis;
 
+import org.apache.storm.task.TopologyContext;
+
 import java.io.Serializable;
 import java.util.Map;
 
@@ -12,7 +14,7 @@ public interface FailureHandler extends Serializable {
      * Lifecycle method.  Called once the Spout has started.
      * @param stormConfig Configuration map passed from the spout.
      */
-    void open(final Map<String, Object> stormConfig);
+    void open(final Map<String, Object> stormConfig, final TopologyContext topologyContext);
 
     /**
      * Handle a failed message.

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
@@ -81,7 +81,7 @@ public class RedisStreamSpout implements IRichSpout {
         this.collector = Objects.requireNonNull(spoutOutputCollector);
 
         // Create funnel instance.
-        this.funnel = new MemoryFunnel(config, spoutConfig);
+        this.funnel = new MemoryFunnel(config, spoutConfig, topologyContext);
 
         // Create consumer and client
         final int taskIndex = topologyContext.getThisTaskIndex();

--- a/src/main/java/org/sourcelab/storm/spout/redis/failhandler/ExponentialBackoffConfig.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/failhandler/ExponentialBackoffConfig.java
@@ -33,18 +33,26 @@ public class ExponentialBackoffConfig implements Serializable {
     private final long retryDelayMaxMs;
 
     /**
+     * Enable/Disable flag for collecting metrics.
+     * Defaults to enabled.
+     */
+    private final boolean metricsEnabled;
+
+    /**
      * Constructor.  See Builder instance.
      */
     public ExponentialBackoffConfig(
         final int retryLimit,
         final long initialRetryDelayMs,
         final double retryDelayMultiplier,
-        final long retryDelayMaxMs
+        final long retryDelayMaxMs,
+        final boolean metricsEnabled
     ) {
         this.retryLimit = retryLimit;
         this.initialRetryDelayMs = initialRetryDelayMs;
         this.retryDelayMultiplier = retryDelayMultiplier;
         this.retryDelayMaxMs = retryDelayMaxMs;
+        this.metricsEnabled = metricsEnabled;
     }
 
     /**
@@ -71,6 +79,10 @@ public class ExponentialBackoffConfig implements Serializable {
         return retryDelayMaxMs;
     }
 
+    public boolean isMetricsEnabled() {
+        return metricsEnabled;
+    }
+
     @Override
     public String toString() {
         return "ExponentialBackoffConfig{"
@@ -78,6 +90,7 @@ public class ExponentialBackoffConfig implements Serializable {
             + ", initialRetryDelayMs=" + initialRetryDelayMs
             + ", retryDelayMultiplier=" + retryDelayMultiplier
             + ", retryDelayMaxMs=" + retryDelayMaxMs
+            + ", metricsEnabled=" + metricsEnabled
             + '}';
     }
 
@@ -106,6 +119,12 @@ public class ExponentialBackoffConfig implements Serializable {
          * Defaults to a max of 15 minutes.
          */
         private long retryDelayMaxMs = TimeUnit.MINUTES.toMillis(15);
+
+        /**
+         * Enable/Disable flag for collecting metrics.
+         * Defaults to enabled.
+         */
+        private boolean metricsEnabled = true;
 
         private Builder() {
         }
@@ -148,12 +167,25 @@ public class ExponentialBackoffConfig implements Serializable {
             return this;
         }
 
+        public Builder withMetricsEnabled() {
+            return withMetricsEnabled(true);
+        }
+
+        public Builder withMetricsDisabled() {
+            return withMetricsEnabled(false);
+        }
+
+        public Builder withMetricsEnabled(final boolean enabled) {
+            this.metricsEnabled = enabled;
+            return this;
+        }
+
         /**
          * Create new ExponentialBackoffConfig instance.
          * @return ExponentialBackoffConfig.
          */
         public ExponentialBackoffConfig build() {
-            return new ExponentialBackoffConfig(retryLimit, initialRetryDelayMs, retryDelayMultiplier, retryDelayMaxMs);
+            return new ExponentialBackoffConfig(retryLimit, initialRetryDelayMs, retryDelayMultiplier, retryDelayMaxMs, metricsEnabled);
         }
     }
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/failhandler/ExponentialBackoffConfig.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/failhandler/ExponentialBackoffConfig.java
@@ -167,12 +167,12 @@ public class ExponentialBackoffConfig implements Serializable {
             return this;
         }
 
-        public Builder withMetricsEnabled() {
-            return withMetricsEnabled(true);
-        }
-
         public Builder withMetricsDisabled() {
             return withMetricsEnabled(false);
+        }
+
+        public Builder withMetricsEnabled() {
+            return withMetricsEnabled(true);
         }
 
         public Builder withMetricsEnabled(final boolean enabled) {

--- a/src/main/java/org/sourcelab/storm/spout/redis/failhandler/NoRetryHandler.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/failhandler/NoRetryHandler.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.failhandler;
 
+import org.apache.storm.task.TopologyContext;
 import org.sourcelab.storm.spout.redis.FailureHandler;
 import org.sourcelab.storm.spout.redis.Message;
 
@@ -12,7 +13,7 @@ import java.util.Map;
  */
 public class NoRetryHandler implements FailureHandler, Serializable {
     @Override
-    public void open(final Map<String, Object> stormConfig) {
+    public void open(final Map<String, Object> stormConfig, final TopologyContext topologyContext) {
         // Noop.
     }
 

--- a/src/main/java/org/sourcelab/storm/spout/redis/failhandler/RetryFailedTuples.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/failhandler/RetryFailedTuples.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.failhandler;
 
+import org.apache.storm.task.TopologyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sourcelab.storm.spout.redis.FailureHandler;
@@ -46,7 +47,7 @@ public class RetryFailedTuples implements FailureHandler, Serializable {
     }
 
     @Override
-    public void open(final Map<String, Object> stormConfig) {
+    public void open(final Map<String, Object> stormConfig, final TopologyContext topologyContext) {
         // no-op
     }
 

--- a/src/main/java/org/sourcelab/storm/spout/redis/funnel/MemoryFunnel.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/funnel/MemoryFunnel.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.funnel;
 
+import org.apache.storm.task.TopologyContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sourcelab.storm.spout.redis.FailureHandler;
@@ -53,7 +54,11 @@ public class MemoryFunnel implements SpoutFunnel, ConsumerFunnel {
      * Constructor.
      * @param config configuration proeprties.
      */
-    public MemoryFunnel(final RedisStreamSpoutConfig config, final Map<String, Object> stormConfig) {
+    public MemoryFunnel(
+        final RedisStreamSpoutConfig config,
+        final Map<String, Object> stormConfig,
+        final TopologyContext topologyContext
+    ) {
         Objects.requireNonNull(config);
 
         // This instance does NOT need to be concurrent.
@@ -65,7 +70,7 @@ public class MemoryFunnel implements SpoutFunnel, ConsumerFunnel {
 
         // Create failure handler instance
         failureHandler = config.getFailureHandler();
-        failureHandler.open(stormConfig);
+        failureHandler.open(stormConfig, topologyContext);
     }
 
     @Override

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/ConsumerTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/ConsumerTest.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.client;
 
+import org.apache.storm.task.TopologyContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -53,14 +54,15 @@ class ConsumerTest {
 
     // Mocks
     private Client mockClient;
+    private TopologyContext mockTopologyContext;
 
     // Instance under test
     private Consumer consumer;
 
-
     @BeforeEach
     void setup() {
-        funnel = new MemoryFunnel(config, new HashMap<>());
+        mockTopologyContext = mock(TopologyContext.class);
+        funnel = new MemoryFunnel(config, new HashMap<>(), mockTopologyContext);
         mockClient = mock(Client.class);
         consumer = new Consumer(config, mockClient, funnel);
 

--- a/src/test/java/org/sourcelab/storm/spout/redis/failhandler/NoRetryHandlerTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/failhandler/NoRetryHandlerTest.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.failhandler;
 
+import org.apache.storm.task.TopologyContext;
 import org.junit.jupiter.api.Test;
 import org.sourcelab.storm.spout.redis.FailureHandler;
 import org.sourcelab.storm.spout.redis.Message;
@@ -8,6 +9,7 @@ import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
 
 class NoRetryHandlerTest {
 
@@ -19,7 +21,7 @@ class NoRetryHandlerTest {
         final FailureHandler handler = new NoRetryHandler();
 
         // Call no-op methods
-        handler.open(new HashMap<>());
+        handler.open(new HashMap<>(), mock(TopologyContext.class));
         handler.ack("MsgId");
 
         // Create message

--- a/src/test/java/org/sourcelab/storm/spout/redis/failhandler/RetryFailedTuplesTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/failhandler/RetryFailedTuplesTest.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.failhandler;
 
+import org.apache.storm.task.TopologyContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -16,8 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class RetryFailedTuplesTest {
+    private final TopologyContext mockTopologyContext = mock(TopologyContext.class);
 
     /**
      * Verify that messages are retried up to the maximum configured limit.
@@ -32,12 +35,9 @@ class RetryFailedTuplesTest {
         final Map<String, String> body = Collections.singletonMap("MyKey", "MyValue");
         final Message message = new Message(msgId, body);
 
-        // Configure with 2 retries
-        final Map<String, Object> stormConfig = new HashMap<>();
-
         // Create instance
         final RetryFailedTuples handler = new RetryFailedTuples(maxLimit);
-        handler.open(stormConfig);
+        handler.open(new HashMap<>(), mockTopologyContext);
 
         // If we ask for the next message, it should return null
         assertNull(handler.getMessage(), "Should have no msgs");
@@ -93,12 +93,9 @@ class RetryFailedTuplesTest {
         final Map<String, String> body = Collections.singletonMap("MyKey", "MyValue");
         final Message message = new Message(msgId, body);
 
-        // Configure with -1 retries (always retry)
-        final Map<String, Object> stormConfig = new HashMap<>();
-
         // Create instance
         final RetryFailedTuples handler = new RetryFailedTuples(cfgValue);
-        handler.open(stormConfig);
+        handler.open(new HashMap<>(), mockTopologyContext);
 
         // If we ask for the next message, it should return null
         assertNull(handler.getMessage(), "Should have no msgs");
@@ -141,12 +138,9 @@ class RetryFailedTuplesTest {
         final Map<String, String> body = Collections.singletonMap("MyKey", "MyValue");
         final Message message = new Message(msgId, body);
 
-        // Configure with -1 retries (always retry)
-        final Map<String, Object> stormConfig = new HashMap<>();
-
         // Create instance
         final RetryFailedTuples handler = new RetryFailedTuples(maxLimit);
-        handler.open(stormConfig);
+        handler.open(new HashMap<>(), mockTopologyContext);
 
         // If we ask for the next message, it should return null
         assertNull(handler.getMessage(), "Should have no msgs");

--- a/src/test/java/org/sourcelab/storm/spout/redis/funnel/MemoryFunnelTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/funnel/MemoryFunnelTest.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis.funnel;
 
+import org.apache.storm.task.TopologyContext;
 import org.junit.jupiter.api.Test;
 import org.sourcelab.storm.spout.redis.Message;
 import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
@@ -15,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class MemoryFunnelTest {
 
@@ -45,7 +47,7 @@ class MemoryFunnelTest {
         final Message message3 = new Message(msgId3, Collections.singletonMap("Key3", "Value3"));
 
         // Create funnel
-        final MemoryFunnel funnel = new MemoryFunnel(config, new HashMap<>());
+        final MemoryFunnel funnel = new MemoryFunnel(config, new HashMap<>(), mock(TopologyContext.class));
 
         // Ask for message, should be empty
         assertNull(funnel.nextMessage(), "Should have no messages");
@@ -98,7 +100,7 @@ class MemoryFunnelTest {
         final String msgId3 = "MyMsgId3";
 
         // Create funnel
-        final MemoryFunnel funnel = new MemoryFunnel(config, new HashMap<>());
+        final MemoryFunnel funnel = new MemoryFunnel(config, new HashMap<>(), mock(TopologyContext.class));
 
         // Ask for acks, should be empty
         assertNull(funnel.nextAck(), "Should have no acks");
@@ -159,7 +161,7 @@ class MemoryFunnelTest {
         final Message message3 = new Message(msgId3, Collections.singletonMap("Key3", "Value3"));
 
         // Create funnel
-        final MemoryFunnel funnel = new MemoryFunnel(config, stormConfig);
+        final MemoryFunnel funnel = new MemoryFunnel(config, new HashMap<>(), mock(TopologyContext.class));
 
         // Push msgs into funnel
         funnel.addMessage(message1);


### PR DESCRIPTION
Extends the FailureHandler interface with the ability to access and register metrics via TopologyContext.

Updates ExponentialBackoff handler to register relevant metrics.