### PR TITLE
Add implementation using Jedis client library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,11 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.0 (07/24/2020)
+- Add Jedis implementation.  Spout defaults to using the Lettuce redis library, but you can configure
+  to use the Jedis library instead via the `RedisStreamSpoutConfig.withJedisClientLibrary()` method.
+- Bugfix on Spout deploy, consumer thread started during `open()` lifecycle call instead of `activate()`. 
+- Bugfix on Spout restart, resume consuming first from consumers personal pending list.
+
 ## 1.0.0 (07/20/2020)
 - Initial release!

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
         <!-- Redis Client -->
         <lettuceVersion>5.3.1.RELEASE</lettuceVersion>
+        <jedisVersion>3.2.0</jedisVersion>
 
         <!-- Define which version of JUnit 5 to -->
         <junit5Version>5.6.2</junit5Version>
@@ -77,6 +78,11 @@
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
             <version>${lettuceVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>${jedisVersion}</version>
         </dependency>
 
         <!-- Testing Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sourcelab.storm.spout</groupId>
     <artifactId>redis-stream-spout</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <!-- Module Description and Ownership -->
     <name>Redis Streams Spout for Apache Storm.</name>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,14 @@
             <version>${testContainersVersion}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Async Testing Helper -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
@@ -9,7 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sourcelab.storm.spout.redis.client.Client;
 import org.sourcelab.storm.spout.redis.client.Consumer;
-import org.sourcelab.storm.spout.redis.client.LettuceClient;
+import org.sourcelab.storm.spout.redis.client.lettuce.LettuceClient;
 import org.sourcelab.storm.spout.redis.funnel.ConsumerFunnel;
 import org.sourcelab.storm.spout.redis.funnel.MemoryFunnel;
 import org.sourcelab.storm.spout.redis.funnel.SpoutFunnel;

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
@@ -84,16 +84,8 @@ public class RedisStreamSpout implements IRichSpout, AutoCloseable {
         // Create funnel instance.
         this.funnel = new MemoryFunnel(config, spoutConfig, topologyContext);
 
-        // Create consumer and client
-        final int taskIndex = topologyContext.getThisTaskIndex();
-        final Client client = new ClientFactory().createClient(config, taskIndex);
-        final Consumer consumer = new Consumer(config, client, (ConsumerFunnel) funnel);
-
-        // Create background consuming thread.
-        consumerThread = new Thread(
-            consumer,
-            "RedisStreamSpout-ConsumerThread[" + taskIndex + "]"
-        );
+        // Create and start consumer thread.
+        createAndStartConsumerThread();
     }
 
     @Override
@@ -104,12 +96,15 @@ public class RedisStreamSpout implements IRichSpout, AutoCloseable {
 
     @Override
     public void activate() {
-        if (consumerThread.isAlive()) {
+        // If the thread is already running and alive
+        if (consumerThread != null && consumerThread.isAlive()) {
             // No-op.  It's already running, and deactivate() is a no-op for us.
             return;
         }
-        // Start thread, this should return immediately, but start a background processing thread.
-        consumerThread.start();
+
+        // If we haven't created the consumer thread yet, or it has previously died.
+        // Create and start it
+        createAndStartConsumerThread();
     }
 
     @Override
@@ -186,5 +181,22 @@ public class RedisStreamSpout implements IRichSpout, AutoCloseable {
     @Override
     public Map<String, Object> getComponentConfiguration() {
         return new HashMap<>();
+    }
+
+    /**
+     * Create background consumer thread.
+     */
+    private void createAndStartConsumerThread() {
+        // Create consumer and client
+        final int taskIndex = topologyContext.getThisTaskIndex();
+        final Client client = new ClientFactory().createClient(config, taskIndex);
+        final Consumer consumer = new Consumer(config, client, (ConsumerFunnel) funnel);
+
+        // Create background consuming thread.
+        consumerThread = new Thread(
+            consumer,
+            "RedisStreamSpout-ConsumerThread[" + taskIndex + "]"
+        );
+        consumerThread.start();
     }
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpout.java
@@ -8,6 +8,7 @@ import org.apache.storm.tuple.Fields;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sourcelab.storm.spout.redis.client.Client;
+import org.sourcelab.storm.spout.redis.client.ClientFactory;
 import org.sourcelab.storm.spout.redis.client.Consumer;
 import org.sourcelab.storm.spout.redis.client.lettuce.LettuceClient;
 import org.sourcelab.storm.spout.redis.funnel.ConsumerFunnel;
@@ -85,7 +86,7 @@ public class RedisStreamSpout implements IRichSpout, AutoCloseable {
 
         // Create consumer and client
         final int taskIndex = topologyContext.getThisTaskIndex();
-        final Client client = new LettuceClient(config, taskIndex);
+        final Client client = new ClientFactory().createClient(config, taskIndex);
         final Consumer consumer = new Consumer(config, client, (ConsumerFunnel) funnel);
 
         // Create background consuming thread.

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
@@ -1,5 +1,6 @@
 package org.sourcelab.storm.spout.redis;
 
+import org.sourcelab.storm.spout.redis.client.ClientType;
 import org.sourcelab.storm.spout.redis.failhandler.NoRetryHandler;
 
 import java.io.Serializable;
@@ -71,6 +72,11 @@ public class RedisStreamSpoutConfig implements Serializable {
     private final boolean metricsEnabled;
 
     /**
+     * Defines which underlying client library/implementation to use.
+     */
+    private final ClientType clientType;
+
+    /**
      * Constructor.
      * Use Builder instance.
      */
@@ -85,7 +91,7 @@ public class RedisStreamSpoutConfig implements Serializable {
 
         // Other settings
         final int maxConsumePerRead, final int maxTupleQueueSize, final int maxAckQueueSize, final long consumerDelayMillis,
-        final boolean metricsEnabled
+        final boolean metricsEnabled, final ClientType clientType
     ) {
         // Connection
         if (redisCluster != null && redisServer != null) {
@@ -117,6 +123,9 @@ public class RedisStreamSpoutConfig implements Serializable {
         this.maxAckQueueSize = maxAckQueueSize;
         this.consumerDelayMillis = consumerDelayMillis;
         this.metricsEnabled = metricsEnabled;
+
+        // Client type implementation
+        this.clientType = Objects.requireNonNull(clientType);
     }
 
     public String getStreamKey() {
@@ -185,6 +194,10 @@ public class RedisStreamSpoutConfig implements Serializable {
         return metricsEnabled;
     }
 
+    public ClientType getClientType() {
+        return clientType;
+    }
+
     /**
      * Create a new Builder instance.
      * @return Builder for Configuration instance.
@@ -228,6 +241,12 @@ public class RedisStreamSpoutConfig implements Serializable {
         private int maxAckQueueSize = 1024;
         private long consumerDelayMillis = 1000L;
         private boolean metricsEnabled = true;
+
+        /**
+         * Underlying library to use.
+         * Defaults to using Lettuce.
+         */
+        private ClientType clientType = ClientType.LETTUCE;
 
         private Builder() {
         }
@@ -396,6 +415,19 @@ public class RedisStreamSpoutConfig implements Serializable {
             return this;
         }
 
+        public Builder withLettuceClientLibrary() {
+            return withClientType(ClientType.LETTUCE);
+        }
+
+        public Builder withJedisClientLibrary() {
+            return withClientType(ClientType.JEDIS);
+        }
+
+        public Builder withClientType(final ClientType clientType) {
+            this.clientType = Objects.requireNonNull(clientType);
+            return this;
+        }
+
         /**
          * Creates new Configuration instance.
          * @return Configuration instance.
@@ -416,7 +448,10 @@ public class RedisStreamSpoutConfig implements Serializable {
                 tupleConverter, failureHandler,
                 // Other settings
                 maxConsumePerRead, maxTupleQueueSize, maxAckQueueSize, consumerDelayMillis,
-                metricsEnabled
+                metricsEnabled,
+
+                // Underlying client type
+                clientType
             );
         }
     }

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
@@ -415,10 +415,18 @@ public class RedisStreamSpoutConfig implements Serializable {
             return this;
         }
 
+        /**
+         * Configure the spout to use the Lettuce client library for communicating with redis.
+         * @return Builder instance.
+         */
         public Builder withLettuceClientLibrary() {
             return withClientType(ClientType.LETTUCE);
         }
 
+        /**
+         * Configure the spout to use the Jedis client library for communicating with redis.
+         * @return Builder instance.
+         */
         public Builder withJedisClientLibrary() {
             return withClientType(ClientType.JEDIS);
         }

--- a/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/RedisStreamSpoutConfig.java
@@ -150,6 +150,17 @@ public class RedisStreamSpoutConfig implements Serializable {
         return redisCluster.getConnectString();
     }
 
+    /**
+     * The URI for connecting to this Redis Server instance with the password masked.
+     * @return URI for the server.
+     */
+    public String getConnectStringMasked() {
+        if (!isConnectingToCluster()) {
+            return redisServer.getConnectStringMasked();
+        }
+        return redisCluster.getConnectStringMasked();
+    }
+
     public int getMaxTupleQueueSize() {
         return maxTupleQueueSize;
     }
@@ -445,6 +456,16 @@ public class RedisStreamSpoutConfig implements Serializable {
                 .map(RedisServer::getConnectString)
                 .collect(Collectors.joining(","));
         }
+
+        /**
+         * The URI for connecting to this Redis Server instance with the password masked.
+         * @return URI for the server.
+         */
+        public String getConnectStringMasked() {
+            return getServers().stream()
+                .map(RedisServer::getConnectStringMasked)
+                .collect(Collectors.joining(","));
+        }
     }
 
     /**
@@ -497,6 +518,21 @@ public class RedisStreamSpoutConfig implements Serializable {
 
             if (getPassword() != null && !getPassword().trim().isEmpty()) {
                 connectStr += getPassword() + "@";
+            }
+            connectStr += getHost() + ":" + getPort();
+
+            return connectStr;
+        }
+
+        /**
+         * The URI for connecting to this Redis Server instance with the password masked.
+         * @return URI for the server.
+         */
+        public String getConnectStringMasked() {
+            String connectStr = "redis://";
+
+            if (getPassword() != null && !getPassword().trim().isEmpty()) {
+                connectStr += "XXXXXX@";
             }
             connectStr += getHost() + ":" + getPort();
 

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/ClientFactory.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/ClientFactory.java
@@ -1,0 +1,37 @@
+package org.sourcelab.storm.spout.redis.client;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.jedis.JedisClient;
+import org.sourcelab.storm.spout.redis.client.lettuce.LettuceClient;
+
+import java.util.Objects;
+
+/**
+ * Factory for creating the appropriate Client instance based on config.
+ */
+public class ClientFactory {
+    private static final Logger logger = LoggerFactory.getLogger(ClientFactory.class);
+
+    /**
+     * Create the appropriate client intance based on configuration.
+     * @param config Spout configuration.
+     * @param instanceId Instance id of spout.
+     * @return Client.
+     */
+    public Client createClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        Objects.requireNonNull(config);
+
+        switch (config.getClientType()) {
+            case JEDIS:
+                logger.info("Using Jedis client library.");
+                return new JedisClient(config, instanceId);
+            case LETTUCE:
+                logger.info("Using Lettuce client library.");
+                return new LettuceClient(config, instanceId);
+            default:
+                throw new IllegalStateException("Unknown/Unhandled Client Type");
+        }
+    }
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/ClientType.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/ClientType.java
@@ -1,0 +1,9 @@
+package org.sourcelab.storm.spout.redis.client;
+
+/**
+ * Defines allowed implementations.
+ */
+public enum ClientType {
+    LETTUCE,
+    JEDIS;
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
@@ -10,26 +10,35 @@ import java.util.Map;
  */
 public interface JedisAdapter {
     /**
-     * Is the underlying client connected?
-     * @return true if connected, false if not.
-     */
-    boolean isConnected();
-
-    /**
      * Call connect.
      */
     void connect();
 
+    /**
+     * Consume next batch of messages.
+     * @return List of messages consumed.
+     */
     List<Map.Entry<String, List<StreamEntry>>> consume();
 
+    /**
+     * Mark the provided messageId as acknowledged/completed.
+     * @param msgId Id of the message.
+     */
     void commit(final String msgId);
 
     /**
-     * Call shutdown.
+     * Disconnect client.
      */
     void close();
 
+    /**
+     * Advance the last offset consumed from PPL.
+     * @param lastMsgId Id of the last msg consumed.
+     */
     void advancePplOffset(final String lastMsgId);
 
+    /**
+     * Switch to consuming from latest messages.
+     */
     void switchToConsumerGroupMessages();
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
@@ -29,7 +29,7 @@ public interface JedisAdapter {
      */
     void close();
 
-    void switchToPpl(final String lastMsgId);
+    void advancePplOffset(final String lastMsgId);
 
     void switchToConsumerGroupMessages();
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisAdapter.java
@@ -1,0 +1,35 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import redis.clients.jedis.StreamEntry;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adapter to allow usage of both Jedis and JedisCluster.
+ */
+public interface JedisAdapter {
+    /**
+     * Is the underlying client connected?
+     * @return true if connected, false if not.
+     */
+    boolean isConnected();
+
+    /**
+     * Call connect.
+     */
+    void connect();
+
+    List<Map.Entry<String, List<StreamEntry>>> consume();
+
+    void commit(final String msgId);
+
+    /**
+     * Call shutdown.
+     */
+    void close();
+
+    void switchToPpl(final String lastMsgId);
+
+    void switchToConsumerGroupMessages();
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
@@ -70,7 +70,7 @@ public class JedisClient implements Client {
         adapter.connect();
 
         // Start consuming from PPL at first entry.
-        adapter.switchToPpl("0-0");
+        adapter.advancePplOffset("0-0");
     }
 
     @Override
@@ -96,7 +96,7 @@ public class JedisClient implements Client {
             } else {
                 // Advance last index consumed from PPL so we don't continue to replay old messages.
                 final String lastId = messages.get(messages.size() - 1).getId();
-                adapter.switchToPpl(lastId);
+                adapter.advancePplOffset(lastId);
             }
         }
         return messages;

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
@@ -1,0 +1,114 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.storm.spout.redis.Message;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.Client;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Redis Stream Consumer using the Jedi java library.
+ */
+public class JedisClient implements Client {
+    private static final Logger logger = LoggerFactory.getLogger(JedisClient.class);
+
+    /**
+     * The underlying Redis Client.
+     */
+    private final JedisAdapter adapter;
+
+    /**
+     * State for consuming first from consumer's personal pending list,
+     * then switching to reading from consumer group messages.
+     */
+    private boolean hasFinishedPpl = false;
+
+    /**
+     * Constructor.
+     * @param config Configuration.
+     * @param instanceId Which instance number is this running under.
+     */
+    public JedisClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        this(
+            // Determine which adapter to use based on what type of redis instance we are
+            // communicating with.
+            JedisClient.createAdapter(config, instanceId)
+        );
+    }
+
+    private static JedisAdapter createAdapter(final RedisStreamSpoutConfig config, final int instanceId) {
+        final String connectStr = config.getConnectString().replaceAll("redis://", "");
+        if (config.isConnectingToCluster()) {
+            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
+            return new JedisClusterAdapter(new JedisCluster(HostAndPort.parseString(connectStr)), config, instanceId);
+        } else {
+            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
+            return new JedisRedisAdapter(new Jedis(HostAndPort.parseString(connectStr)), config, instanceId);
+        }
+    }
+
+    /**
+     * Protected constructor for injecting a RedisClient instance, typically for tests.
+     * @param adapter JedisAdapter instance.
+     */
+    JedisClient(final JedisAdapter adapter) {
+        this.adapter = Objects.requireNonNull(adapter);
+    }
+
+    @Override
+    public void connect() {
+        // Connect
+        adapter.connect();
+
+        // Start consuming from PPL at first entry.
+        adapter.switchToPpl("0-0");
+    }
+
+    @Override
+    public List<Message> nextMessages() {
+        final List<Message> messages = adapter.consume()
+            .stream()
+            .map(Map.Entry::getValue)
+            .flatMap(Collection::stream)
+            .map((entry) -> new Message(entry.getID().toString(), entry.getFields()))
+            .collect(Collectors.toList());
+
+        // If we haven't finished consuming from PPL, but we received no messages
+        if (!hasFinishedPpl) {
+            if (messages.isEmpty()) {
+                logger.info("Personal Pending List appears empty, switching to consuming from new messages.");
+
+                // Switch to reading from consumer group
+                hasFinishedPpl = true;
+                adapter.switchToConsumerGroupMessages();
+
+                // Re-attempt consuming
+                return nextMessages();
+            } else {
+                // Advance last index consumed from PPL so we don't continue to replay old messages.
+                final String lastId = messages.get(messages.size() - 1).getId();
+                adapter.switchToPpl(lastId);
+            }
+        }
+        return messages;
+    }
+
+    @Override
+    public void commitMessage(final String msgId) {
+        adapter.commit(msgId);
+    }
+
+    @Override
+    public void disconnect() {
+        adapter.close();
+    }
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient.java
@@ -45,17 +45,6 @@ public class JedisClient implements Client {
         );
     }
 
-    private static JedisAdapter createAdapter(final RedisStreamSpoutConfig config, final int instanceId) {
-        final String connectStr = config.getConnectString().replaceAll("redis://", "");
-        if (config.isConnectingToCluster()) {
-            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
-            return new JedisClusterAdapter(new JedisCluster(HostAndPort.parseString(connectStr)), config, instanceId);
-        } else {
-            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
-            return new JedisRedisAdapter(new Jedis(HostAndPort.parseString(connectStr)), config, instanceId);
-        }
-    }
-
     /**
      * Protected constructor for injecting a RedisClient instance, typically for tests.
      * @param adapter JedisAdapter instance.
@@ -110,5 +99,21 @@ public class JedisClient implements Client {
     @Override
     public void disconnect() {
         adapter.close();
+    }
+
+    /**
+     * Factory method for creating the appropriate adapter based on configuration.
+     * @param config Spout configuration.
+     * @return Appropriate Adapter.
+     */
+    private static JedisAdapter createAdapter(final RedisStreamSpoutConfig config, final int instanceId) {
+        final String connectStr = config.getConnectString().replaceAll("redis://", "");
+        if (config.isConnectingToCluster()) {
+            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
+            return new JedisClusterAdapter(new JedisCluster(HostAndPort.parseString(connectStr)), config, instanceId);
+        } else {
+            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
+            return new JedisRedisAdapter(new Jedis(HostAndPort.parseString(connectStr)), config, instanceId);
+        }
     }
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
@@ -63,7 +63,7 @@ public class JedisClusterAdapter implements JedisAdapter {
         }
 
         // Default to requesting entries from our personal pending queue.
-        switchToPpl("0-0");
+        advancePplOffset("0-0");
     }
 
     @Override
@@ -98,7 +98,7 @@ public class JedisClusterAdapter implements JedisAdapter {
     }
 
     @Override
-    public void switchToPpl(final String lastMsgId) {
+    public void advancePplOffset(final String lastMsgId) {
         streamPositionKey = new AbstractMap.SimpleEntry<>(
             config.getStreamKey(),
             new StreamEntryID(lastMsgId)

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
@@ -1,0 +1,115 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ *
+ */
+public class JedisClusterAdapter implements JedisAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(JedisClusterAdapter.class);
+
+    private final JedisCluster jedisCluster;
+
+    /**
+     * Configuration properties for the client.
+     */
+    private final RedisStreamSpoutConfig config;
+
+    /**
+     * Generated from config.getConsumerIdPrefix() along with the spout's instance
+     * id to come to a unique consumerId to support parallelism.
+     */
+    private final String consumerId;
+
+    /**
+     * Contains the position key to read from.
+     */
+    private Map.Entry<String, StreamEntryID> streamPositionKey;
+
+    public JedisClusterAdapter(final JedisCluster jedisCluster, final RedisStreamSpoutConfig config, final int instanceId) {
+        this.jedisCluster = Objects.requireNonNull(jedisCluster);
+        this.config = Objects.requireNonNull(config);
+        this.consumerId = config.getConsumerIdPrefix() + instanceId;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
+
+    @Override
+    public void connect() {
+        // Attempt to create consumer group
+        try {
+            jedisCluster.xgroupCreate(config.getStreamKey(), config.getGroupName(), new StreamEntryID(), true);
+        } catch (final JedisDataException exception) {
+            // Consumer group already exists, that's ok. Just swallow this.
+            logger.debug(
+                "Group {} for key {} already exists? : {}", config.getGroupName(), config.getStreamKey(),
+                exception.getMessage(), exception
+            );
+        }
+
+        // Default to requesting entries from our personal pending queue.
+        switchToPpl("0-0");
+    }
+
+    @Override
+    public List<Map.Entry<String, List<StreamEntry>>> consume() {
+        final List<Map.Entry<String, List<StreamEntry>>> entries = jedisCluster.xreadGroup(
+            config.getGroupName(),
+            consumerId,
+            config.getMaxConsumePerRead(),
+            2000L,
+            false,
+            streamPositionKey
+        );
+
+        if (entries == null) {
+            return Collections.emptyList();
+        }
+        return entries;
+    }
+
+    @Override
+    public void commit(final String msgId) {
+        jedisCluster.xack(
+            config.getStreamKey(),
+            config.getGroupName(),
+            new StreamEntryID(msgId)
+        );
+    }
+
+    @Override
+    public void close() {
+        jedisCluster.close();
+    }
+
+    @Override
+    public void switchToPpl(final String lastMsgId) {
+        streamPositionKey = new AbstractMap.SimpleEntry<>(
+            config.getStreamKey(),
+            new StreamEntryID(lastMsgId)
+        );
+    }
+
+    @Override
+    public void switchToConsumerGroupMessages() {
+        streamPositionKey = new AbstractMap.SimpleEntry<>(
+            config.getStreamKey(),
+            StreamEntryID.UNRECEIVED_ENTRY
+        );
+    }
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClusterAdapter.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- *
+ * Adapter for talking to a RedisCluster.
+ * If you need to talk to a single Redis instance {@link JedisRedisAdapter}.
  */
 public class JedisClusterAdapter implements JedisAdapter {
     private static final Logger logger = LoggerFactory.getLogger(JedisClusterAdapter.class);
@@ -38,15 +39,16 @@ public class JedisClusterAdapter implements JedisAdapter {
      */
     private Map.Entry<String, StreamEntryID> streamPositionKey;
 
+    /**
+     * Constructor.
+     * @param jedisCluster Underlying Jedis Cluster client instance.
+     * @param config Spout configuration.
+     * @param instanceId Spout instance Id.
+     */
     public JedisClusterAdapter(final JedisCluster jedisCluster, final RedisStreamSpoutConfig config, final int instanceId) {
         this.jedisCluster = Objects.requireNonNull(jedisCluster);
         this.config = Objects.requireNonNull(config);
         this.consumerId = config.getConsumerIdPrefix() + instanceId;
-    }
-
-    @Override
-    public boolean isConnected() {
-        return true;
     }
 
     @Override

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- *
+ * Adapter for talking to a single Redis instance.
+ * If you need to talk to a RedisCluster {@link JedisClusterAdapter}.
  */
 public class JedisRedisAdapter implements JedisAdapter {
     private static final Logger logger = LoggerFactory.getLogger(JedisRedisAdapter.class);
@@ -38,15 +39,16 @@ public class JedisRedisAdapter implements JedisAdapter {
      */
     private Map.Entry<String, StreamEntryID> streamPositionKey;
 
+    /**
+     * Constructor.
+     * @param jedis Underlying Jedis client instance.
+     * @param config Spout configuration.
+     * @param instanceId Spout instance Id.
+     */
     public JedisRedisAdapter(final Jedis jedis, final RedisStreamSpoutConfig config, final int instanceId) {
         this.jedis = Objects.requireNonNull(jedis);
         this.config = Objects.requireNonNull(config);
         this.consumerId = config.getConsumerIdPrefix() + instanceId;
-    }
-
-    @Override
-    public boolean isConnected() {
-        return jedis.isConnected();
     }
 
     @Override

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
@@ -65,7 +65,7 @@ public class JedisRedisAdapter implements JedisAdapter {
         }
 
         // Default to requesting entries from our personal pending queue.
-        switchToPpl("0-0");
+        advancePplOffset("0-0");
     }
 
     @Override
@@ -94,7 +94,7 @@ public class JedisRedisAdapter implements JedisAdapter {
     }
 
     @Override
-    public void switchToPpl(final String lastMsgId) {
+    public void advancePplOffset(final String lastMsgId) {
         streamPositionKey = new AbstractMap.SimpleEntry<>(
             config.getStreamKey(),
             new StreamEntryID(lastMsgId)

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/jedis/JedisRedisAdapter.java
@@ -1,0 +1,111 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.StreamEntry;
+import redis.clients.jedis.StreamEntryID;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ *
+ */
+public class JedisRedisAdapter implements JedisAdapter {
+    private static final Logger logger = LoggerFactory.getLogger(JedisRedisAdapter.class);
+
+    private final Jedis jedis;
+
+    /**
+     * Configuration properties for the client.
+     */
+    private final RedisStreamSpoutConfig config;
+
+    /**
+     * Generated from config.getConsumerIdPrefix() along with the spout's instance
+     * id to come to a unique consumerId to support parallelism.
+     */
+    private final String consumerId;
+
+    /**
+     * Contains the position key to read from.
+     */
+    private Map.Entry<String, StreamEntryID> streamPositionKey;
+
+    public JedisRedisAdapter(final Jedis jedis, final RedisStreamSpoutConfig config, final int instanceId) {
+        this.jedis = Objects.requireNonNull(jedis);
+        this.config = Objects.requireNonNull(config);
+        this.consumerId = config.getConsumerIdPrefix() + instanceId;
+    }
+
+    @Override
+    public boolean isConnected() {
+        return jedis.isConnected();
+    }
+
+    @Override
+    public void connect() {
+        jedis.connect();
+
+        // Attempt to create consumer group
+        try {
+            jedis.xgroupCreate(config.getStreamKey(), config.getGroupName(), new StreamEntryID(), true);
+        } catch (final JedisDataException exception) {
+            // Consumer group already exists, that's ok. Just swallow this.
+            logger.debug(
+                "Group {} for key {} already exists? : {}", config.getGroupName(), config.getStreamKey(),
+                exception.getMessage(), exception
+            );
+        }
+
+        // Default to requesting entries from our personal pending queue.
+        switchToPpl("0-0");
+    }
+
+    @Override
+    public List<Map.Entry<String, List<StreamEntry>>> consume() {
+        final List<Map.Entry<String, List<StreamEntry>>> entries = jedis.xreadGroup(
+            config.getGroupName(),
+            consumerId,
+            config.getMaxConsumePerRead(),
+            2000L,
+            false,
+            streamPositionKey
+        );
+        if (entries == null) {
+            return Collections.emptyList();
+        }
+        return entries;
+    }
+
+    public void commit(final String msgId) {
+        jedis.xack(config.getStreamKey(), config.getGroupName(), new StreamEntryID(msgId));
+    }
+
+    @Override
+    public void close() {
+        jedis.quit();
+    }
+
+    @Override
+    public void switchToPpl(final String lastMsgId) {
+        streamPositionKey = new AbstractMap.SimpleEntry<>(
+            config.getStreamKey(),
+            new StreamEntryID(lastMsgId)
+        );
+    }
+
+    @Override
+    public void switchToConsumerGroupMessages() {
+        streamPositionKey = new AbstractMap.SimpleEntry<>(
+            config.getStreamKey(),
+            StreamEntryID.UNRECEIVED_ENTRY
+        );
+    }
+}

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceAdapter.java
@@ -1,4 +1,4 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
 import io.lettuce.core.api.sync.RedisStreamCommands;
 

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient.java
@@ -67,16 +67,6 @@ public class LettuceClient implements Client {
         );
     }
 
-    private static LettuceAdapter createAdapter(final RedisStreamSpoutConfig config) {
-        if (config.isConnectingToCluster()) {
-            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
-            return new LettuceClusterAdapter(RedisClusterClient.create(config.getConnectString()));
-        } else {
-            logger.info("Connecting to Redis server at {}", config.getConnectStringMasked());
-            return new LettuceRedisAdapter(RedisClient.create(config.getConnectString()));
-        }
-    }
-
     /**
      * Protected constructor for injecting a RedisClient instance, typically for tests.
      * @param config Configuration.
@@ -187,5 +177,20 @@ public class LettuceClient implements Client {
     @Override
     public void disconnect() {
         adapter.shutdown();
+    }
+
+    /**
+     * Factory method for creating the appropriate adapter based on configuration.
+     * @param config Spout configuration.
+     * @return Appropriate Adapter.
+     */
+    private static LettuceAdapter createAdapter(final RedisStreamSpoutConfig config) {
+        if (config.isConnectingToCluster()) {
+            logger.info("Connecting to RedisCluster at {}", config.getConnectStringMasked());
+            return new LettuceClusterAdapter(RedisClusterClient.create(config.getConnectString()));
+        } else {
+            logger.info("Connecting to Redis server at {}", config.getConnectStringMasked());
+            return new LettuceRedisAdapter(RedisClient.create(config.getConnectString()));
+        }
     }
 }

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClusterAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClusterAdapter.java
@@ -1,29 +1,28 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisStreamCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 
 import java.util.Objects;
 
 /**
- * Adapter for talking to a single Redis instance.
- * If you need to talk to a RedisCluster {@link LettuceClusterAdapter}.
+ * Adapter for talking to a RedisCluster.
+ * If you need to talk to a single Redis instance {@link LettuceRedisAdapter}.
  */
-public class LettuceRedisAdapter implements LettuceAdapter {
-
+public class LettuceClusterAdapter implements LettuceAdapter {
     /**
      * The underlying Redis Client.
      */
-    private final RedisClient redisClient;
+    private final RedisClusterClient redisClient;
 
     /**
      * Underlying connection objects.
      */
-    private StatefulRedisConnection<String, String> connection;
+    private StatefulRedisClusterConnection<String, String> connection;
     private RedisStreamCommands<String, String> syncCommands;
 
-    public LettuceRedisAdapter(final RedisClient redisClient) {
+    public LettuceClusterAdapter(final RedisClusterClient redisClient) {
         this.redisClient = Objects.requireNonNull(redisClient);
     }
 

--- a/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceRedisAdapter.java
+++ b/src/main/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceRedisAdapter.java
@@ -1,28 +1,29 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisStreamCommands;
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 
 import java.util.Objects;
 
 /**
- * Adapter for talking to a RedisCluster.
- * If you need to talk to a single Redis instance {@link LettuceRedisAdapter}.
+ * Adapter for talking to a single Redis instance.
+ * If you need to talk to a RedisCluster {@link LettuceClusterAdapter}.
  */
-public class LettuceClusterAdapter implements LettuceAdapter {
+public class LettuceRedisAdapter implements LettuceAdapter {
+
     /**
      * The underlying Redis Client.
      */
-    private final RedisClusterClient redisClient;
+    private final RedisClient redisClient;
 
     /**
      * Underlying connection objects.
      */
-    private StatefulRedisClusterConnection<String, String> connection;
+    private StatefulRedisConnection<String, String> connection;
     private RedisStreamCommands<String, String> syncCommands;
 
-    public LettuceClusterAdapter(final RedisClusterClient redisClient) {
+    public LettuceRedisAdapter(final RedisClient redisClient) {
         this.redisClient = Objects.requireNonNull(redisClient);
     }
 

--- a/src/test/java/org/sourcelab/storm/spout/redis/AbstractRedisStreamSpoutIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/AbstractRedisStreamSpoutIntegrationTest.java
@@ -9,6 +9,9 @@ import org.apache.storm.utils.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.sourcelab.storm.spout.redis.client.ClientType;
 import org.sourcelab.storm.spout.redis.example.TestTupleConverter;
 import org.sourcelab.storm.spout.redis.failhandler.RetryFailedTuples;
 import org.sourcelab.storm.spout.redis.util.outputcollector.EmittedTuple;
@@ -101,8 +104,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Most basic lifecycle smoke test.
      */
-    @Test
-    void smokeTest_openAndClose() {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void smokeTest_openAndClose(final ClientType clientType) {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create spout
         try (final RedisStreamSpout spout = new RedisStreamSpout(configBuilder.build())) {
 
@@ -121,8 +128,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Basic lifecycle smoke test.
      */
-    @Test
-    void smokeTest_openActivateDeactivateAndClose() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void smokeTest_openActivateDeactivateAndClose(final ClientType clientType) throws InterruptedException {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create spout
         try (final RedisStreamSpout spout = new RedisStreamSpout(configBuilder.build())) {
             final StubSpoutCollector collector = new StubSpoutCollector();
@@ -150,7 +161,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
      *
      * Disabled for now.
      */
-    void smokeTest_configureInvalidRedisHost() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void smokeTest_configureInvalidRedisHost(final ClientType clientType) throws InterruptedException {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Lets override the redis host with something invalid
         configBuilder
             .withServer(getTestContainer().getHost(), 124);
@@ -186,8 +202,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Basic usage test.
      */
-    @Test
-    void smokeTest_consumeAndAckMessages() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void smokeTest_consumeAndAckMessages(final ClientType clientType) throws InterruptedException {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create spout
         try (final RedisStreamSpout spout = new RedisStreamSpout(configBuilder.build())) {
             final StubSpoutCollector collector = new StubSpoutCollector();
@@ -274,8 +294,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Basic usage with retry failure handler.
      */
-    @Test
-    void smokeTest_consumeFailAndAckMessages() throws InterruptedException {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void smokeTest_consumeFailAndAckMessages(final ClientType clientType) throws InterruptedException {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Swap out failure handler
         configBuilder.withFailureHandler(new RetryFailedTuples(2));
 
@@ -397,8 +421,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Verify declareOutputFields using TestTupleConverter.
      */
-    @Test
-    void test_declareOutputFields() {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void test_declareOutputFields(final ClientType clientType) {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create a test implementation
         final TupleConverter converter = new DummyTupleConverter() ;
 
@@ -444,8 +472,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
     /**
      * Verify spout emits tuples down the correct stream.
      */
-    @Test
-    void test_EmitDownSeparateStreams() {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void test_EmitDownSeparateStreams(final ClientType clientType) {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create a test implementation
         final TupleConverter converter = new DummyTupleConverter() ;
 
@@ -503,8 +535,12 @@ abstract class AbstractRedisStreamSpoutIntegrationTest {
      * Verify if tuple converter instance returns null, then the message
      * is simply acked and nothing is emitted.
      */
-    @Test
-    void test_NullConversionJustGetsAckedNothingEmitted() {
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void test_NullConversionJustGetsAckedNothingEmitted(final ClientType clientType) {
+        // Inject client type into config
+        configBuilder.withClientType(clientType);
+
         // Create a test implementation
         final TupleConverter converter = new NullTupleConverter() ;
 

--- a/src/test/java/org/sourcelab/storm/spout/redis/AbstractRedisStreamSpoutIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/AbstractRedisStreamSpoutIntegrationTest.java
@@ -1,10 +1,8 @@
 package org.sourcelab.storm.spout.redis;
 
 import org.apache.storm.generated.StreamInfo;
-import org.apache.storm.spout.ISpout;
 import org.apache.storm.spout.SpoutOutputCollector;
 import org.apache.storm.task.TopologyContext;
-import org.apache.storm.topology.IRichSpout;
 import org.apache.storm.topology.OutputFieldsGetter;
 import org.apache.storm.tuple.Fields;
 import org.apache.storm.utils.Utils;

--- a/src/test/java/org/sourcelab/storm/spout/redis/RedisStreamSpout_ClusterIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/RedisStreamSpout_ClusterIntegrationTest.java
@@ -6,7 +6,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
- *
+ * Runs Spout integration tests against a RedisCluster.
  */
 @Testcontainers
 @Tag("Integration")

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient_RedisClusterIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient_RedisClusterIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import org.junit.jupiter.api.Tag;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.AbstractClientIntegrationTest;
+import org.sourcelab.storm.spout.redis.client.Client;
+import org.sourcelab.storm.spout.redis.util.test.RedisTestContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * NOTE: This Integration test requires Docker to run.
+ *
+ * This integration test verifies JedisClient against a RedisCluster instance to verify
+ * things work as expected when consuming from a RedisCluster.
+ *
+ * Test cases are defined in {@link AbstractClientIntegrationTest}.
+ */
+@Testcontainers
+@Tag("Integration")
+public class JedisClient_RedisClusterIntegrationTest extends AbstractClientIntegrationTest {
+    /**
+     * This test depends on the following Redis Container.
+     */
+    @Container
+    public RedisTestContainer redisContainer = RedisTestContainer.newRedisContainer();
+
+    @Override
+    public RedisTestContainer getTestContainer() {
+        return redisContainer;
+    }
+
+    @Override
+    public Client createClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        return new JedisClient(config, instanceId);
+    }
+}

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient_RedisIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/jedis/JedisClient_RedisIntegrationTest.java
@@ -1,0 +1,37 @@
+package org.sourcelab.storm.spout.redis.client.jedis;
+
+import org.junit.jupiter.api.Tag;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.AbstractClientIntegrationTest;
+import org.sourcelab.storm.spout.redis.client.Client;
+import org.sourcelab.storm.spout.redis.util.test.RedisTestContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * NOTE: This Integration test requires Docker to run.
+ *
+ * This integration test verifies JedisClient against a Redis instance to verify
+ * things work as expected when consuming from a Redis instance.
+ *
+ * Test cases are defined in {@link AbstractClientIntegrationTest}.
+ */
+@Testcontainers
+@Tag("Integration")
+public class JedisClient_RedisIntegrationTest extends AbstractClientIntegrationTest {
+    /**
+     * This test depends on the following Redis Container.
+     */
+    @Container
+    public RedisTestContainer redisContainer = RedisTestContainer.newRedisContainer();
+
+    @Override
+    public RedisTestContainer getTestContainer() {
+        return redisContainer;
+    }
+
+    @Override
+    public Client createClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        return new JedisClient(config, instanceId);
+    }
+}

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient_RedisClusterIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient_RedisClusterIntegrationTest.java
@@ -1,6 +1,9 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
 import org.junit.jupiter.api.Tag;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.AbstractClientIntegrationTest;
+import org.sourcelab.storm.spout.redis.client.Client;
 import org.sourcelab.storm.spout.redis.util.test.RedisTestContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -11,11 +14,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * This integration test verifies LettuceClient against a RedisCluster instance to verify
  * things work as expected when consuming from a RedisCluster.
  *
- * Test cases are defined in {@link AbstractLettuceClientIntegrationTest}.
+ * Test cases are defined in {@link AbstractClientIntegrationTest}.
  */
 @Testcontainers
 @Tag("Integration")
-public class LettuceClient_RedisClusterIntegrationTest extends AbstractLettuceClientIntegrationTest {
+public class LettuceClient_RedisClusterIntegrationTest extends AbstractClientIntegrationTest {
     /**
      * This test depends on the following Redis Container.
      */
@@ -23,7 +26,12 @@ public class LettuceClient_RedisClusterIntegrationTest extends AbstractLettuceCl
     public RedisTestContainer redisContainer = RedisTestContainer.newRedisClusterContainer();
 
     @Override
-    RedisTestContainer getTestContainer() {
+    public RedisTestContainer getTestContainer() {
         return redisContainer;
+    }
+
+    @Override
+    public Client createClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        return new LettuceClient(config, instanceId);
     }
 }

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient_RedisIntegrationTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClient_RedisIntegrationTest.java
@@ -1,6 +1,9 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
 import org.junit.jupiter.api.Tag;
+import org.sourcelab.storm.spout.redis.RedisStreamSpoutConfig;
+import org.sourcelab.storm.spout.redis.client.AbstractClientIntegrationTest;
+import org.sourcelab.storm.spout.redis.client.Client;
 import org.sourcelab.storm.spout.redis.util.test.RedisTestContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -11,11 +14,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
  * This integration test verifies LettuceClient against a Redis instance to verify
  * things work as expected when consuming from a Redis instance.
  *
- * Test cases are defined in {@link AbstractLettuceClientIntegrationTest}.
+ * Test cases are defined in {@link AbstractClientIntegrationTest}.
  */
 @Testcontainers
 @Tag("Integration")
-public class LettuceClient_RedisIntegrationTest extends AbstractLettuceClientIntegrationTest {
+public class LettuceClient_RedisIntegrationTest extends AbstractClientIntegrationTest {
     /**
      * This test depends on the following Redis Container.
      */
@@ -23,7 +26,12 @@ public class LettuceClient_RedisIntegrationTest extends AbstractLettuceClientInt
     public RedisTestContainer redisContainer = RedisTestContainer.newRedisContainer();
 
     @Override
-    RedisTestContainer getTestContainer() {
+    public RedisTestContainer getTestContainer() {
         return redisContainer;
+    }
+
+    @Override
+    public Client createClient(final RedisStreamSpoutConfig config, final int instanceId) {
+        return new LettuceClient(config, instanceId);
     }
 }

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClusterAdapterTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceClusterAdapterTest.java
@@ -1,8 +1,8 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
+import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,36 +16,35 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-class LettuceRedisAdapterTest {
-
-    private RedisClient mockRedisClient;
-    private StatefulRedisConnection mockConnection;
+class LettuceClusterAdapterTest {
+    private RedisClusterClient mockClusterClient;
+    private StatefulRedisClusterConnection mockConnection;
 
     @BeforeEach
     void setup() {
-        mockRedisClient = mock(RedisClient.class);
-        mockConnection = mock(StatefulRedisConnection.class);
+        mockClusterClient = mock(RedisClusterClient.class);
+        mockConnection = mock(StatefulRedisClusterConnection.class);
     }
 
     @AfterEach
     void cleanup() {
-        verifyNoMoreInteractions(mockRedisClient);
+        verifyNoMoreInteractions(mockClusterClient);
         verifyNoMoreInteractions(mockConnection);
     }
 
     @Test
     void testAdapter() {
-        final RedisCommands<String, String> mockCommands = mock(RedisCommands.class);
+        final RedisAdvancedClusterCommands<String, String> mockCommands = mock(RedisAdvancedClusterCommands.class);
 
         // Setup mocks
-        when(mockRedisClient.connect())
+        when(mockClusterClient.connect())
             .thenReturn(mockConnection);
 
         when(mockConnection.sync())
             .thenReturn(mockCommands);
 
         // Create instance
-        final LettuceRedisAdapter adapter = new LettuceRedisAdapter(mockRedisClient);
+        final LettuceClusterAdapter adapter = new LettuceClusterAdapter(mockClusterClient);
 
         // Verify "not connected"
         assertFalse(adapter.isConnected(), "Should return false");
@@ -57,7 +56,7 @@ class LettuceRedisAdapterTest {
         assertTrue(adapter.isConnected(), "Should return true");
 
         // Verify interactions
-        verify(mockRedisClient, times(1))
+        verify(mockClusterClient, times(1))
             .connect();
 
         // Call sync multiple times
@@ -73,6 +72,6 @@ class LettuceRedisAdapterTest {
         adapter.shutdown();
 
         verify(mockConnection, times(1)).close();
-        verify(mockRedisClient, times(1)).shutdown();
+        verify(mockClusterClient, times(1)).shutdown();
     }
 }

--- a/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceRedisAdapterTest.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/client/lettuce/LettuceRedisAdapterTest.java
@@ -1,8 +1,8 @@
-package org.sourcelab.storm.spout.redis.client;
+package org.sourcelab.storm.spout.redis.client.lettuce;
 
-import io.lettuce.core.cluster.RedisClusterClient;
-import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
-import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,35 +16,36 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-class LettuceClusterAdapterTest {
-    private RedisClusterClient mockClusterClient;
-    private StatefulRedisClusterConnection mockConnection;
+class LettuceRedisAdapterTest {
+
+    private RedisClient mockRedisClient;
+    private StatefulRedisConnection mockConnection;
 
     @BeforeEach
     void setup() {
-        mockClusterClient = mock(RedisClusterClient.class);
-        mockConnection = mock(StatefulRedisClusterConnection.class);
+        mockRedisClient = mock(RedisClient.class);
+        mockConnection = mock(StatefulRedisConnection.class);
     }
 
     @AfterEach
     void cleanup() {
-        verifyNoMoreInteractions(mockClusterClient);
+        verifyNoMoreInteractions(mockRedisClient);
         verifyNoMoreInteractions(mockConnection);
     }
 
     @Test
     void testAdapter() {
-        final RedisAdvancedClusterCommands<String, String> mockCommands = mock(RedisAdvancedClusterCommands.class);
+        final RedisCommands<String, String> mockCommands = mock(RedisCommands.class);
 
         // Setup mocks
-        when(mockClusterClient.connect())
+        when(mockRedisClient.connect())
             .thenReturn(mockConnection);
 
         when(mockConnection.sync())
             .thenReturn(mockCommands);
 
         // Create instance
-        final LettuceClusterAdapter adapter = new LettuceClusterAdapter(mockClusterClient);
+        final LettuceRedisAdapter adapter = new LettuceRedisAdapter(mockRedisClient);
 
         // Verify "not connected"
         assertFalse(adapter.isConnected(), "Should return false");
@@ -56,7 +57,7 @@ class LettuceClusterAdapterTest {
         assertTrue(adapter.isConnected(), "Should return true");
 
         // Verify interactions
-        verify(mockClusterClient, times(1))
+        verify(mockRedisClient, times(1))
             .connect();
 
         // Call sync multiple times
@@ -72,6 +73,6 @@ class LettuceClusterAdapterTest {
         adapter.shutdown();
 
         verify(mockConnection, times(1)).close();
-        verify(mockClusterClient, times(1)).shutdown();
+        verify(mockRedisClient, times(1)).shutdown();
     }
 }

--- a/src/test/java/org/sourcelab/storm/spout/redis/util/test/RedisTestHelper.java
+++ b/src/test/java/org/sourcelab/storm/spout/redis/util/test/RedisTestHelper.java
@@ -3,9 +3,9 @@ package org.sourcelab.storm.spout.redis.util.test;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.sync.RedisStreamCommands;
 import io.lettuce.core.cluster.RedisClusterClient;
-import org.sourcelab.storm.spout.redis.client.LettuceAdapter;
-import org.sourcelab.storm.spout.redis.client.LettuceClusterAdapter;
-import org.sourcelab.storm.spout.redis.client.LettuceRedisAdapter;
+import org.sourcelab.storm.spout.redis.client.lettuce.LettuceAdapter;
+import org.sourcelab.storm.spout.redis.client.lettuce.LettuceClusterAdapter;
+import org.sourcelab.storm.spout.redis.client.lettuce.LettuceRedisAdapter;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
- Add Jedis implementation.  Spout defaults to using the Lettuce redis library, but you can configure
  to use the Jedis library instead via the `RedisStreamSpoutConfig.withJedisClientLibrary()` method.
- Bugfix on Spout deploy, consumer thread started during `open()` lifecycle call instead of `activate()`. 
- Bugfix on Spout restart, resume consuming first from consumers personal pending list.